### PR TITLE
Changed window position generation to be safer for height

### DIFF
--- a/js/autocompaste/interface.js
+++ b/js/autocompaste/interface.js
@@ -169,12 +169,13 @@ AutoComPaste.Interface = (function () {
 
       // Position the window randomly.
       //
-      // safety_bounds ensures that the window is at least some pixels within 
+      // safety_bounds ensure that the window is at least some pixels within 
       // the boundaries of the display.
-      var safety_bounds = 50;
+      var height_safety_bounds = privates.wm.getDisplayHeight()/1.5;
+      var width_safety_bounds = privates.wm.getDisplayWidth()/5;
       privates.wm.moveWindowTo(text_title,
-        Math.random() * (privates.wm.getDisplayWidth() - safety_bounds) + (safety_bounds / 2),
-        Math.random() * (privates.wm.getDisplayHeight() - safety_bounds) + (safety_bounds / 2)
+        Math.random() * (privates.wm.getDisplayWidth() - width_safety_bounds),
+        Math.random() * (privates.wm.getDisplayHeight() - height_safety_bounds)
       );
     };
 


### PR DESCRIPTION
Creates separate safety bounds for width and height, the height bound being far more conservative to ensure most of the window is within the display. The width bound tries to ensure the windows are scattered across the page so they aren't all bunched together.

Reason for change: While using Autocompaste, a window would sometimes be generated quite close to the bottom of the display. If I used Ctrl+F to search for text that was hidden below the display, it would jump to that section of the text, as shown in this screenshot:

![2](https://cloud.githubusercontent.com/assets/4407837/10069186/0cdd6b06-62dd-11e5-85f8-e410bb9a1d3b.png)

This led to multiple problems. The first was not being able to go back to the text editor window (the scrollbar doesn't scroll back up there), and the second was a problem with dragging windows:

![3](https://cloud.githubusercontent.com/assets/4407837/10069220/4f5f115a-62dd-11e5-8c2a-715527251d7f.png)

I would try to drag a window upwards, and what would happen is that the header would disappear beyond the upper limit of the display, as shown in the screenshot. Because I was dragging that window, it would be permanently selected since my cursor wouldn't be able to reach the header anymore to deselect it.

tl;dr doesn't strictly fix the problems, but it makes it far less likely that they would be encountered at all.
